### PR TITLE
Disable checkboxes for policies with subscription

### DIFF
--- a/src/services/Api.js
+++ b/src/services/Api.js
@@ -11,6 +11,14 @@ class Api {
         });
     }
 
+    /**
+     * Fetches all available policies
+     * @returns {Promise<AxiosResponse<any>>}
+     */
+    fetchAvailablePolicies() {
+        return Axios.get("/getAllPolicies");
+    }
+
     fetchSubscribedPoliciesByCompanyId(companyId) {
         return Axios.get("/getSubscribedPoliciesByCompanyId", {
             params: {

--- a/src/views/dashboardUserSubPage/SurveyResult.jsx
+++ b/src/views/dashboardUserSubPage/SurveyResult.jsx
@@ -65,7 +65,6 @@ class MatchedPolicies extends React.Component {
           this.setState({availablePolicies: res.data});
         })
         .catch(err => {
-          console.log("Error");
           console.log(err);
         });
   }

--- a/src/views/dashboardUserSubPage/SurveyResult.jsx
+++ b/src/views/dashboardUserSubPage/SurveyResult.jsx
@@ -76,7 +76,6 @@ class MatchedPolicies extends React.Component {
           this.setState({subscribedPolicies: res.data});
         })
         .catch(err => {
-          console.log("Error");
           console.log(err);
         });
   }


### PR DESCRIPTION
Was implemented as the easiest measure to prevent multiple
subscription, and a way to indicate what policies a client is
subscribed to.

Also removed some stuff what didn't work.